### PR TITLE
Typos in both workflows causing failures

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,9 +31,9 @@ jobs:
               id: aws-credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:
-                role-to-assume: $${{ env.AWS_ROLE_ARN }}
-                role-session-name: $${{ env.AWS_ROLE_SESSION_NAME }}
-                aws-region: $${{ env.AWS_REGION }}
+                role-to-assume: ${{ env.AWS_ROLE_ARN }}
+                role-session-name: ${{ env.AWS_ROLE_SESSION_NAME }}
+                aws-region: ${{ env.AWS_REGION }}
                 output-credentials: true
 
             - name: Check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
               id: aws-credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:
-                role-to-assume: $${{ env.AWS_ROLE_ARN }}
-                role-session-name: $${{ env.AWS_ROLE_SESSION_NAME }}
-                aws-region: $${{ env.AWS_REGION }}
+                role-to-assume: ${{ env.AWS_ROLE_ARN }}
+                role-session-name: ${{ env.AWS_ROLE_SESSION_NAME }}
+                aws-region: ${{ env.AWS_REGION }}
                 output-credentials: true
 
             - name: Get Release Bot Token
@@ -117,7 +117,7 @@ jobs:
                     echo "Bumping version from $CURRENT_TAG to $NEXT_TAG"
                     task bump-${{ steps.determine_bump.outputs.bump }}
                     task build-all
-                    if [ "$${{ github.event_name }}" = "workflow_dispatch" ] && [ "$${{ github.event.inputs.snapshot }}" = "true" ]; then
+                    if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.snapshot }}" = "true" ]; then
                         task release-snapshot
                     else
                         task release


### PR DESCRIPTION
Had a few $$ where there should have only been $. It was causing pr-checks to fail and would have also failed the release workflow had it triggered.