### PR TITLE
Adding ECR publishing permissions before release

### DIFF
--- a/infrastructure/aws/pub/README.md
+++ b/infrastructure/aws/pub/README.md
@@ -34,5 +34,7 @@ No outputs.
 | [aws_cloudwatch_event_bus.deployer_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_bus) | resource |
 | [aws_cloudwatch_event_rule.console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_iam_role_policy.actions_ecr_publish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_iam_policy_document.actions_ecr_publish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 <!-- END_TF_DOCS -->

--- a/infrastructure/modules/aws/ecr/README.md
+++ b/infrastructure/modules/aws/ecr/README.md
@@ -18,11 +18,14 @@ URI, which can be used for pushing and pulling images.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_image_publish_role_arn"></a> [image\_publish\_role\_arn](#input\_image\_publish\_role\_arn) | Role ARN of the publisher | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name for the ECR Repository to be created | `string` | n/a | yes |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_ecr_arn"></a> [ecr\_arn](#output\_ecr\_arn) | ARN of the ECR repository |
 
 ## Resources
 

--- a/infrastructure/modules/aws/ecr/main.tf
+++ b/infrastructure/modules/aws/ecr/main.tf
@@ -61,4 +61,25 @@ data "aws_iam_policy_document" "account" {
       "ecr:ListImages",
     ]
   }
+  statement {
+    sid    = "AllowActionsPublish"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.image_publish_role_arn]
+    }
+
+    actions = [
+      "ecr:CompleteLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:InitiateLayerUpload",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:BatchGetImage"
+    ]
+    resources = [
+      aws_ecr_repository.ecr.arn
+    ]
+  }
 }

--- a/infrastructure/modules/aws/ecr/outputs.tf
+++ b/infrastructure/modules/aws/ecr/outputs.tf
@@ -1,0 +1,4 @@
+output "ecr_arn" {
+  description = "ARN of the ECR repository"
+  value       = aws_ecr_repository.ecr.arn
+}

--- a/infrastructure/modules/aws/ecr/variables.tf
+++ b/infrastructure/modules/aws/ecr/variables.tf
@@ -1,3 +1,8 @@
+variable "image_publish_role_arn" {
+  description = "Role ARN of the publisher"
+  type        = string
+}
+
 variable "name" {
   description = "Name for the ECR Repository to be created"
   type        = string


### PR DESCRIPTION
Ensure our OIDC actions role can push the lambda function image to ECR during the release workflow.

This PR will get a bump label to trigger the release workflow for testing.