### PR TITLE
base_ref != base.ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
   release:
     if: >-
       (github.event.pull_request.merged == true &&
-      github.event.pull_request.base_ref == 'main' &&
+      github.event.pull_request.base.ref == 'main' &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'bump:')) ||
       github.event_name == 'workflow_dispatch'
     runs-on:


### PR DESCRIPTION
This is the main problem with the release workflow trigger.