### PR TITLE
Fetch tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetchDepth: 0
+        tags: true
 
     - name: Determine bump type
       id: determine_bump

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -140,19 +140,14 @@ tasks:
 
   release:
     desc: Create a new release
-    deps:
-      - lint
-      - test
     env:
       GITHUB_TOKEN: '{{.GITHUB_TOKEN}}'
     cmds:
       - goreleaser release --clean
+      - task publish_image
 
   release-snapshot:
     desc: Create a snapshot release
-    deps:
-      - lint
-      - test
     env:
       GITHUB_TOKEN: '{{.GITHUB_TOKEN}}'
     cmds:


### PR DESCRIPTION
The release workflow needs to fetch tags during checkout in order to understand what it needs to do.