### PR TITLE
No need to run tidy it has already been run

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,9 +1,5 @@
 version: 2
 
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - id: deployer_lambda
     dir: ./lambda_functions/deployer


### PR DESCRIPTION
goreleaser does not need to run go mod tidy we have already done that well before goreleaser is called.