### PR TITLE
Fix the docker stuff (no need to log in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,77 @@ go.work
 # End of https://www.toptal.com/developers/gitignore/api/go
 artifacts/
 .direnv
+dist/
+# Created by https://www.toptal.com/developers/gitignore/api/go
+# Edit at https://www.toptal.com/developers/gitignore?templates=go
+
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# End of https://www.toptal.com/developers/gitignore/api/go
+# Created by https://www.toptal.com/developers/gitignore/api/dist
+# Edit at https://www.toptal.com/developers/gitignore?templates=dist
+
+#!! ERROR: dist is undefined. Use list command to see defined gitignore types !!#
+
+# End of https://www.toptal.com/developers/gitignore/api/dist
+# Created by https://www.toptal.com/developers/gitignore/api/terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform

--- a/README.md
+++ b/README.md
@@ -6,67 +6,67 @@ This repository contains the infrastructure as code (IaC) for a deployment pipel
 
 The infrastructure is divided into two main parts:
 
-*   **Publisher:** Responsible for publishing ECR push events to an SNS topic.
-*   **Subscriber:** Responsible for subscribing to the SNS topic and triggering a Lambda function when new images are pushed to ECR.
+* **Publisher:** Responsible for publishing ECR push events to an SNS topic.
+* **Subscriber:** Responsible for subscribing to the SNS topic and triggering a Lambda function when new images are pushed to ECR.
 
 ### Modules
 
 The following OpenTofu modules are used to create the infrastructure:
 
-*   **[modules/aws/context](infrastructure/modules/aws/context/README.md):** Provides AWS context information such as account ID, region, and partition.
-*   **[modules/aws/ecr](infrastructure/modules/aws/ecr/README.md):** Creates and manages an ECR repository for storing container images.
-*   **[modules/aws/lambda](infrastructure/modules/aws/lambda/README.md):** Creates and manages a Lambda function for processing events.
-*   **[modules/aws/sns](infrastructure/modules/aws/sns/README.md):** Creates and manages an SNS topic for publishing events.
+* **[modules/aws/context](infrastructure/modules/aws/context/README.md):** Provides AWS context information such as account ID, region, and partition.
+* **[modules/aws/ecr](infrastructure/modules/aws/ecr/README.md):** Creates and manages an ECR repository for storing container images.
+* **[modules/aws/lambda](infrastructure/modules/aws/lambda/README.md):** Creates and manages a Lambda function for processing events.
+* **[modules/aws/sns](infrastructure/modules/aws/sns/README.md):** Creates and manages an SNS topic for publishing events.
 
 ### Components
 
 The following components are created as part of the infrastructure:
 
-*   ECR Repository: Stores the container images for the Lambda function.
-*   Lambda Function: Processes events triggered by ECR push events.
-*   SNS Topic: Publishes ECR push events to subscribers.
-*   CloudWatch Event Bus: Routes events from ECR to the SNS topic.
-*   CloudWatch Event Rule: Filters events from ECR based on the event type.
-*   IAM Roles and Policies: Provide the necessary permissions for the Lambda function and other resources to access AWS services.
-*   SQS Queues: Provides queueing for the lambda function.
+* ECR Repository: Stores the container images for the Lambda function.
+* Lambda Function: Processes events triggered by ECR push events.
+* SNS Topic: Publishes ECR push events to subscribers.
+* CloudWatch Event Bus: Routes events from ECR to the SNS topic.
+* CloudWatch Event Rule: Filters events from ECR based on the event type.
+* IAM Roles and Policies: Provide the necessary permissions for the Lambda function and other resources to access AWS services.
+* SQS Queues: Provides queueing for the lambda function.
 
 ### Publisher ([infrastructure/aws/pub](infrastructure/aws/pub/README.md))
 
 The publisher component is responsible for publishing ECR push events to an SNS topic. It includes the following resources:
 
-*   ECR repository (`deployer_lambda`) to store function's container image.
-*   SNS topic to send notifications about image pushes.
-*   CloudWatch event bus, rule and target to route ECR push events to the SNS topic.
+* ECR repository (`deployer_lambda`) to store function's container image.
+* SNS topic to send notifications about image pushes.
+* CloudWatch event bus, rule and target to route ECR push events to the SNS topic.
 
 ### Subscriber ([infrastructure/aws/sub](infrastructure/aws/sub/README.md))
 
 The subscriber component is responsible for subscribing to the SNS topic and triggering a Lambda function when new images are pushed to ECR. It includes the following resources:
 
-*   Lambda function to process events.
-*   SQS queue to queue events for processing.
-*   IAM roles and policies to provide the necessary permissions for the Lambda function to access AWS services.
+* Lambda function to process events.
+* SQS queue to queue events for processing.
+* IAM roles and policies to provide the necessary permissions for the Lambda function to access AWS services.
 
 ## Getting Started
 
 To get started with this infrastructure, you will need the following:
 
-*   An AWS account
-*   OpenTofu installed
-*   The AWS CLI installed and configured
+* An AWS account
+* OpenTofu installed
+* The AWS CLI installed and configured
 
 ## Deployment
 
 To deploy the infrastructure, follow these steps:
 
-1.  Clone the repository.
-2.  Navigate to the `infrastructure/aws/pub` directory.
-3.  Create `target.tfvars` and `backend.vars` files with the required variables.
-4.  Initialize OpenTofu: `tofu init`
-5.  Apply the OpenTofu configuration: `tofu apply`
-6.  Navigate to the `infrastructure/aws/sub` directory.
-7.  Create `target.tfvars` and `backend.vars` files with the required variables, including the `sns_topic_arn` from the publisher deployment.
-8.  Initialize OpenTofu: `tofu init`
-9.  Apply the OpenTofu configuration: `tofu apply`
+1. Clone the repository.
+2. Navigate to the `infrastructure/aws/pub` directory.
+3. Create `target.tfvars` and `backend.vars` files with the required variables.
+4. Initialize OpenTofu: `tofu init`
+5. Apply the OpenTofu configuration: `tofu apply`
+6. Navigate to the `infrastructure/aws/sub` directory.
+7. Create `target.tfvars` and `backend.vars` files with the required variables, including the `sns_topic_arn` from the publisher deployment.
+8. Initialize OpenTofu: `tofu init`
+9. Apply the OpenTofu configuration: `tofu apply`
 
 ## Contributing
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
     cmds:
       - mkdir -p {{.ARTIFACTS_DIR}}
       - cd {{ .SRC_DIR }} && CGO_ENABLED=0 GOOS=linux GOOS_ARCH=amd64 go build -o
-       ../../{{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-linux-amd64 main.go
+        ../../{{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-linux-amd64 main.go
 
   fmt:
     desc: Run go fmt
@@ -123,17 +123,17 @@ tasks:
       TAG:
         sh: task get-current-tag | tail -n 1
     cmds:
-      - aws ecr get-login-password \
-        --region us-east-1 | docker login \
-        --username AWS \
-        --password-stdin {{ .ECR }}
-      - docker buildx build \
-        --platform=linux/amd64 \
-        --provenance=false
-        -t {{ .ECR }}/{{ .BINARY_NAME }}:latest \
-        -t {{ .ECR }}/{{ .BINARY_NAME }}:{{ .TAG }} \
-        -f {{ .SRC_DIR }}/Dockerfile . \
-        --push
+      - |
+        aws ecr get-login-password --region us-east-1 | docker login \
+          --username AWS \
+          --password-stdin {{ .ECR }}
+        docker buildx build \
+          --platform=linux/amd64 \
+          --provenance=false \
+          -t {{ .ECR }}/{{ .BINARY_NAME }}_lambda:latest \
+          -t {{ .ECR }}/{{ .BINARY_NAME }}_lambda:{{ .TAG }} \
+          -f {{ .SRC_DIR }}/Dockerfile . \
+          --push
 
   release:
     desc: Create a new release
@@ -152,7 +152,7 @@ tasks:
     env:
       GITHUB_TOKEN: '{{.GITHUB_TOKEN}}'
     cmds:
-      - goreleaser release --snapshot --clean --skip=build
+      - goreleaser release --snapshot --clean
 
   pre-commit-install:
     desc: Install pre-commit hooks


### PR DESCRIPTION
Since we aren't running from inside of a devcontainer we can use the runner's IAM role that it assumes via OIDC to push directly to ECR.

We also don't need to use backslashes to separate commands by new line in the Taskfile.yml